### PR TITLE
Downgrade Microsoft.Extensions.* dependencies (#25)

### DIFF
--- a/src/Pomelo.Extensions.Caching.MySql/Pomelo.Extensions.Caching.MySql.csproj
+++ b/src/Pomelo.Extensions.Caching.MySql/Pomelo.Extensions.Caching.MySql.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.10" />
     <PackageReference Include="MySqlConnector" Version="1.3.10" />
   </ItemGroup>
 


### PR DESCRIPTION
To increase compatibility with _.Net Standard 2.0_, we have to downgrade (restore previous values) dependencies to the following packages:
- Microsoft.Extensions.Caching.Abstractions
- Microsoft.Extensions.Options

For example, the current _Caching-MySQL_ version can't be used within _Microsoft.AspNetCore 2.2_ also targets _.Net Standard 2.0_ and _Razor_ has an internal dependency on _Microsoft.Extensions.Primitives >=3.1_ but _Microsoft.Extensions.Options 5.0_ requires _Microsoft.Extensions.Primitives >=5.0_. There is a breaking change between the _3.1_ and _5.0_ versions of _Microsoft.Extensions.Primitives_ (deprecated _Microsoft.Extensions.Primitives.InplaceStringBuilder_ class) so Razor can't be used within _Microsoft.Extensions.Primitives 5.0_.

It looks like _Caching-MySQL_ doesn't use directly any improvements introduced between _3.1_ and _5.0_ versions of the packages mentioned above. So quite dependencies downgrade looks safe.