### PR TITLE
build(deps): bump xunit from 2.5.3 to 2.6.0 (#67)

### DIFF
--- a/test/Pomelo.Extensions.Caching.MySql.Tests/MySqlCacheWithDatabaseTest.cs
+++ b/test/Pomelo.Extensions.Caching.MySql.Tests/MySqlCacheWithDatabaseTest.cs
@@ -742,10 +742,10 @@ namespace Pomelo.Extensions.Caching.MySql.Tests
 				SlidingExpirationInSeconds = TimeSpan.FromSeconds(10)
 			};
 
-			var exception = await Assert.ThrowsAsync<MySqlException>(async () =>
+			var exception = await Assert.ThrowsAsync<MySqlException>((Func<ValueTask>)(async () =>
 			{
 				await SetCacheItemFromDatabaseAsync(key, value);
-			});
+			}));
 			Assert.NotNull(exception);
 			Assert.Equal(1062, exception.Number);
 

--- a/test/Pomelo.Extensions.Caching.MySql.Tests/Pomelo.Extensions.Caching.MySql.Tests.csproj
+++ b/test/Pomelo.Extensions.Caching.MySql.Tests/Pomelo.Extensions.Caching.MySql.Tests.csproj
@@ -24,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.6.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -34,7 +34,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="Moq" Version="4.20.69" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
* Update version

* Escape schema name and table name because the query fails if they contain dots (#18)

Thank you for the PR

* Dev to master (#22)

Merging dev to master branch (Dotnet5 framework changes and MySqlConnector-1.x.x branch)

* Upgrade to GitHub-native Dependabot (#7)



* bump: Microsoft.NET.Test.Sdk

* build(deps): bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 (#41)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.5.0 to 17.6.0.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Changelog](https://github.com/microsoft/vstest/blob/main/docs/releases.md)
- [Commits](https://github.com/microsoft/vstest/compare/v17.5.0...v17.6.0)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-minor ...




* bump: Microsoft.NET.Test.Sdk

* build(deps): bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.1 (#43)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.6.0 to 17.6.1.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Changelog](https://github.com/microsoft/vstest/blob/main/docs/releases.md)
- [Commits](https://github.com/microsoft/vstest/compare/v17.6.0...v17.6.1)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump Microsoft.NET.Test.Sdk from 17.6.1 to 17.6.2 (#10)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.6.1 to 17.6.2.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Changelog](https://github.com/microsoft/vstest/blob/main/docs/releases.md)
- [Commits](https://github.com/microsoft/vstest/compare/v17.6.1...v17.6.2)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump Microsoft.NET.Test.Sdk from 17.6.1 to 17.6.2 (#44)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.6.1 to 17.6.2.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Changelog](https://github.com/microsoft/vstest/blob/main/docs/releases.md)
- [Commits](https://github.com/microsoft/vstest/compare/v17.6.1...v17.6.2)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...




* bump: Microsoft.NET.Test.Sdk

* bumps: xunit, Google.Apis.YouTube.v3

* bump: Microsoft.NET.Test.Sdk

* build(deps): bump Moq from 4.18.4 to 4.20.0 (#14)

Bumps [Moq](https://github.com/moq/moq) from 4.18.4 to 4.20.0.
- [Release notes](https://github.com/moq/moq/releases)
- [Changelog](https://github.com/moq/moq/blob/main/CHANGELOG.md)
- [Commits](https://github.com/moq/moq/compare/v4.18.4...v4.20.0)

---
updated-dependencies:
- dependency-name: Moq dependency-type: direct:production update-type: version-update:semver-minor ...




* bump: Moq

* bump: Moq

* build(deps): bump Moq from 4.20.2 to 4.20.69 (#15)

Bumps [Moq](https://github.com/moq/moq) from 4.20.2 to 4.20.69.
- [Release notes](https://github.com/moq/moq/releases)
- [Changelog](https://github.com/moq/moq/blob/main/CHANGELOG.md)
- [Commits](https://github.com/moq/moq/compare/v4.20.2...v4.20.69)

---
updated-dependencies:
- dependency-name: Moq dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#16)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.7.0 to 17.7.1.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Changelog](https://github.com/microsoft/vstest/blob/main/docs/releases.md)
- [Commits](https://github.com/microsoft/vstest/compare/v17.7.0...v17.7.1)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 (#17)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.7.1 to 17.7.2.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Changelog](https://github.com/microsoft/vstest/blob/main/docs/releases.md)
- [Commits](https://github.com/microsoft/vstest/compare/v17.7.1...v17.7.2)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump xunit.runner.visualstudio from 2.5.0 to 2.5.1 (#18)

Bumps [xunit.runner.visualstudio](https://github.com/xunit/xunit) from 2.5.0 to 2.5.1.
- [Commits](https://github.com/xunit/xunit/compare/2.5.0...2.5.1)

---
updated-dependencies:
- dependency-name: xunit.runner.visualstudio dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump xunit from 2.5.0 to 2.5.1 (#19)

Bumps [xunit](https://github.com/xunit/xunit) from 2.5.0 to 2.5.1.
- [Commits](https://github.com/xunit/xunit/compare/2.5.0...2.5.1)

---
updated-dependencies:
- dependency-name: xunit dependency-type: direct:production update-type: version-update:semver-patch ...




* bump: xunit, xunit.runner.visualstudio

* build(deps): bump xunit from 2.5.2 to 2.5.3 (#22)

Bumps [xunit](https://github.com/xunit/xunit) from 2.5.2 to 2.5.3.
- [Commits](https://github.com/xunit/xunit/commits)

---
updated-dependencies:
- dependency-name: xunit dependency-type: direct:production update-type: version-update:semver-patch ...




* build(deps): bump xunit from 2.5.3 to 2.6.0

---------